### PR TITLE
remove referrence to junit.framework after subnetgroup handler merge

### DIFF
--- a/aws-memorydb-subnetgroup/src/test/java/software/amazon/memorydb/subnetgroup/CreateHandlerTest.java
+++ b/aws-memorydb-subnetgroup/src/test/java/software/amazon/memorydb/subnetgroup/CreateHandlerTest.java
@@ -1,6 +1,5 @@
 package software.amazon.memorydb.subnetgroup;
 
-import junit.framework.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +25,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.time.Duration;
 
-import static junit.framework.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -141,7 +140,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-        Assert.assertEquals(expectedResourceModel, model);
+        assertThat(expectedResourceModel.equals(model));
 
         verify(sdkClient, atLeastOnce()).serviceName();
     }

--- a/aws-memorydb-subnetgroup/src/test/java/software/amazon/memorydb/subnetgroup/DeleteHandlerTest.java
+++ b/aws-memorydb-subnetgroup/src/test/java/software/amazon/memorydb/subnetgroup/DeleteHandlerTest.java
@@ -20,7 +20,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.time.Duration;
 
-import static junit.framework.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;

--- a/aws-memorydb-subnetgroup/src/test/java/software/amazon/memorydb/subnetgroup/ListHandlerTest.java
+++ b/aws-memorydb-subnetgroup/src/test/java/software/amazon/memorydb/subnetgroup/ListHandlerTest.java
@@ -1,6 +1,5 @@
 package software.amazon.memorydb.subnetgroup;
 
-import junit.framework.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,6 +68,6 @@ public class ListHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNotNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-        Assert.assertEquals(expectedResourceStateModel, desiredResourceStateModel);
+        assertThat(expectedResourceStateModel.equals(desiredResourceStateModel));
     }
 }

--- a/aws-memorydb-subnetgroup/src/test/java/software/amazon/memorydb/subnetgroup/ReadHandlerTest.java
+++ b/aws-memorydb-subnetgroup/src/test/java/software/amazon/memorydb/subnetgroup/ReadHandlerTest.java
@@ -1,6 +1,5 @@
 package software.amazon.memorydb.subnetgroup;
 
-import junit.framework.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,6 +80,6 @@ public class ReadHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-        Assert.assertEquals(expectedResourceStateModel, desiredResourceStateModel);
+        assertThat(expectedResourceStateModel.equals(desiredResourceStateModel));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
