### PR TITLE
Renaming contract test user to avoid conflict of duplicate ids

### DIFF
--- a/aws-memorydb-acl/inputs/inputs_1_create.json
+++ b/aws-memorydb-acl/inputs/inputs_1_create.json
@@ -1,7 +1,7 @@
 {
     "ACLName": "acl-contract-test",
     "UserNames": [
-        "user-contract-123456789"
+        "acluser-contract-123456"
     ],
     "Tags": [
         {

--- a/aws-memorydb-acl/inputs/inputs_1_update.json
+++ b/aws-memorydb-acl/inputs/inputs_1_update.json
@@ -1,7 +1,7 @@
 {
     "ACLName": "acl-contract-test",
     "UserNames": [
-        "user-contract-123456789v2"
+        "acluser-contract-123456v2"
     ],
     "Tags": [
         {


### PR DESCRIPTION
*Description of changes:*
Renaming contract test user to avoid conflict of duplicate ids

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
