### PR TITLE
fix issues in Translator.isModified

### DIFF
--- a/aws-memorydb-cluster/sam-tests/updateWithTags.json
+++ b/aws-memorydb-cluster/sam-tests/updateWithTags.json
@@ -8,34 +8,44 @@
             "k2": "v2NewKey"
         },
         "previousResourceTags": {
-            "k1": "v1",
             "service": "memorydb"
         },
         "desiredResourceState": {
-            "ClusterName": "mdb-2021-08-22-21-07-43-250-368569"
+            "ClusterName": "mdb-cfn-test-cluster",
+            "SnsTopicArn": "arn:aws:sns:sa-east-1:662555285474:mdb-sns-topic-1",
+            "SnsTopicStatus": "inactive",
+            "SnapshotWindow": "02:00-04:00",
+            "SnapshotRetentionLimit": 10,
+            "SecurityGroupIds": [
+                "sg-072b320deabd0b180",
+                "sg-234c7b6b"
+            ],
+            "ACLName": "raoadi-acl"
         },
         "previousResourceState": {
-            "ClusterName": "mdb-2021-08-22-21-07-43-250-368569",
-            "Description": "CFN Test MemoryDB cluster",
             "Status": "available",
+            "SubnetGroupName": "default",
+            "NodeType": "db.r6g.large",
+            "ClusterName": "mdb-cfn-test-cluster",
+            "SnapshotRetentionLimit": 0,
+            "TLSEnabled": true,
+            "SnsTopicStatus": "ACTIVE",
+            "ParameterGroupStatus": "in-sync",
+            "ACLName": "open-access",
+            "EnginePatchVersion": "6.2.4",
+            "SnsTopicArn": "arn:aws:sns:sa-east-1:662555285474:mdb-sns-topic",
             "NumberOfShards": 1,
             "ClusterEndpoint": {
-                "Address": "clustercfg.mdb-2021-08-22-21-07-43-250-368569.nneedy.memorydb.ap-south-1.amazonaws.com",
-                "Port": 6379
+                "Port": 6379,
+                "Address": "clustercfg.mdb-cfn-test-cluster.y7bwzf.memorydb.sa-east-1.amazonaws.com"
             },
-            "NodeType": "db.r6g.large",
-            "EngineVersion": "6.2",
-            "EnginePatchVersion": "6.2.4",
             "ParameterGroupName": "default.memorydb-redis6",
-            "ParameterGroupStatus": "in-sync",
-            "SubnetGroupName": "default",
-            "TLSEnabled": true,
-            "ARN": "arn:aws:memorydb:ap-south-1:078013142495:cluster/mdb-2021-08-22-21-07-43-250-368569",
-            "SnapshotRetentionLimit": 0,
-            "MaintenanceWindow": "mon:20:00-mon:21:00",
-            "SnapshotWindow": "06:00-07:00",
-            "ACLName": "open-access",
-            "AutoMinorVersionUpgrade": true
+            "SnapshotWindow": "05:00-06:00",
+            "EngineVersion": "6.2",
+            "AutoMinorVersionUpgrade": true,
+            "MaintenanceWindow": "fri:07:00-fri:08:00",
+            "ARN": "arn:aws:memorydb:sa-east-1:662555285474:cluster/mdb-cfn-test-cluster",
+            "Description": "mdb-cfn-test-cluster"
         },
         "logicalResourceIdentifier": "MyResource"
     },

--- a/aws-memorydb-cluster/src/main/java/software/amazon/memorydb/cluster/Translator.java
+++ b/aws-memorydb-cluster/src/main/java/software/amazon/memorydb/cluster/Translator.java
@@ -1,6 +1,5 @@
 package software.amazon.memorydb.cluster;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -10,6 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.collections.CollectionUtils;
 import software.amazon.awssdk.services.memorydb.model.Cluster;
 import software.amazon.awssdk.services.memorydb.model.CreateClusterRequest;
 import software.amazon.awssdk.services.memorydb.model.DeleteClusterRequest;
@@ -45,7 +45,20 @@ public class Translator {
      * @return true if modification for the property is requested, otherwise false
      */
     static <T> boolean isModified(T desiredValue, T currentValue) {
-        return (desiredValue != null && !desiredValue.equals(currentValue));
+        return (desiredValue != null && (desiredValue instanceof String ?
+                isModifiedIgnoreCase(desiredValue, currentValue)
+                : desiredValue instanceof List ?
+                isModifiedIgnoreOrder(desiredValue, currentValue)
+                : ! desiredValue.equals(currentValue)));
+    }
+
+    private static <T> boolean isModifiedIgnoreOrder(T desiredValue, T currentValue) {
+        return currentValue != null ? ! CollectionUtils.isEqualCollection((List<?>) desiredValue,
+                (List<?>) currentValue) : true;
+    }
+
+    private static <T> boolean isModifiedIgnoreCase(T desiredValue, T currentValue) {
+        return ! ((String) desiredValue).equalsIgnoreCase((String) currentValue);
     }
 
     static CreateClusterRequest translateToCreateRequest(final ResourceModel model, Map<String, String> tags) {

--- a/aws-memorydb-cluster/src/main/java/software/amazon/memorydb/cluster/UpdateHandler.java
+++ b/aws-memorydb-cluster/src/main/java/software/amazon/memorydb/cluster/UpdateHandler.java
@@ -34,7 +34,7 @@ public class UpdateHandler extends BaseHandlerStd {
                                                                           final CallbackContext callbackContext,
                                                                           final ProxyClient<MemoryDbClient> proxyClient,
                                                                           final Logger logger) {
-
+        logger.log(String.format("Resource model: %s", request.getDesiredResourceState()));
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> updateCluster(proxy, proxyClient, progress, request, ClusterUpdateFieldType.DESCRIPTION, logger))
                 .then(progress -> updateCluster(proxy, proxyClient, progress, request, ClusterUpdateFieldType.SECURITY_GROUP_IDS, logger))
@@ -136,7 +136,7 @@ public class UpdateHandler extends BaseHandlerStd {
                                                                 final ResourceModel desiredResourceState,
                                                                 final ClusterUpdateFieldType fieldType,
                                                                 final Logger logger) {
-
+        logger.log(String.format("Updating fieldType : %s" , fieldType.name()));
         return proxy.initiate("AWS-memorydb-Cluster::Update", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest(model -> Translator.translateToUpdateRequest(model, fieldType))
                 .backoffDelay(STABILIZATION_DELAY)


### PR DESCRIPTION
*Issue #, if available:*

SNS update and SecurityGroupIds update was not working for Cluster Handler

Issues:
1. SNS issue - Cluster handler was treating all the parms as case sensitive, but MemoryDB is not.
2. SecurityGroupIds issue - Cluster handler was considering order for the list of security group ids.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
