### PR TITLE
define required params and update docs

### DIFF
--- a/aws-memorydb-cluster/aws-memorydb-cluster.json
+++ b/aws-memorydb-cluster/aws-memorydb-cluster.json
@@ -180,7 +180,9 @@
         "/properties/ParameterGroupStatus"
     ],
     "required": [
-        "ClusterName"
+        "ClusterName",
+        "NodeType",
+        "ACLName"
     ],
     "createOnlyProperties": [
         "/properties/ClusterName",

--- a/aws-memorydb-cluster/docs/README.md
+++ b/aws-memorydb-cluster/docs/README.md
@@ -102,7 +102,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The compute and memory capacity of the nodes in the cluster.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -202,7 +202,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The name of the Access Control List to associate with the cluster.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 

--- a/aws-memorydb-cluster/inputs/inputs_1_create.json
+++ b/aws-memorydb-cluster/inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
-    "ClusterName": "cfncontractcluster2",
+    "ClusterName": "cfncontractcluster",
     "NodeType": "db.r6g.large",
     "NumShards": 1,
     "NumReplicasPerShard": 1,

--- a/aws-memorydb-cluster/inputs/inputs_1_update.json
+++ b/aws-memorydb-cluster/inputs/inputs_1_update.json
@@ -1,11 +1,12 @@
 {
-    "ClusterName": "cfncontractcluster2",
+    "ClusterName": "cfncontractcluster",
     "NodeType": "db.r6g.large",
     "NumShards": 1,
     "Description": "memdb cfn test cluster updated",
     "MaintenanceWindow": "sat:04:30-sat:05:30",
     "SnapshotWindow": "09:30-11:30",
     "SnapshotRetentionLimit": 2,
+    "ACLName": "open-access",
     "Tags": [
         {
             "Key": "k1",

--- a/aws-memorydb-parametergroup/aws-memorydb-parametergroup.json
+++ b/aws-memorydb-parametergroup/aws-memorydb-parametergroup.json
@@ -63,7 +63,8 @@
     },
     "additionalProperties": false,
     "required": [
-        "ParameterGroupName"
+        "ParameterGroupName",
+        "Family"
     ],
     "readOnlyProperties": [
         "/properties/ARN"

--- a/aws-memorydb-parametergroup/docs/README.md
+++ b/aws-memorydb-parametergroup/docs/README.md
@@ -50,7 +50,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 The name of the parameter group family that this parameter group is compatible with.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 

--- a/aws-memorydb-parametergroup/inputs/inputs_1_update.json
+++ b/aws-memorydb-parametergroup/inputs/inputs_1_update.json
@@ -1,5 +1,6 @@
 {
     "ParameterGroupName": "cfncontractcparametergroup2",
+    "Family": "memorydb_redis6",
     "Parameters": {
         "maxmemory-policy": "volatile-random",
         "timeout": "20",

--- a/aws-memorydb-subnetgroup/aws-memorydb-subnetgroup.json
+++ b/aws-memorydb-subnetgroup/aws-memorydb-subnetgroup.json
@@ -65,7 +65,8 @@
     },
     "additionalProperties": false,
     "required": [
-        "SubnetGroupName"
+        "SubnetGroupName",
+        "SubnetIds"
     ],
     "primaryIdentifier": [
         "/properties/SubnetGroupName"

--- a/aws-memorydb-subnetgroup/docs/README.md
+++ b/aws-memorydb-subnetgroup/docs/README.md
@@ -61,7 +61,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 A list of VPC subnet IDs for the subnet group.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: List of String
 


### PR DESCRIPTION
Some of the params which were needed for the resource creation were not marked required as they were not necessarily required during update and other handlers.

*Description of changes:*
1. marked all required params as required in the CFN model for Cluster, ParameterGroup and SubnetGroup resource types.
2. ran contract tests successfully for Cluster and ParameterGroup types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
