### PR TITLE
PG waitForStabilize - add null check for cluster PG properties

### DIFF
--- a/aws-memorydb-parametergroup/src/main/java/software/amazon/memorydb/parametergroup/UpdateHandler.java
+++ b/aws-memorydb-parametergroup/src/main/java/software/amazon/memorydb/parametergroup/UpdateHandler.java
@@ -132,7 +132,9 @@ public class UpdateHandler extends BaseHandlerStd {
                 }
 
                 if (clusters.stream()
-                        .filter(cluster -> cluster.parameterGroupName().equals(request.getDesiredResourceState().getParameterGroupName())) // all db clusters that use param group
+                        .filter(cluster -> cluster.parameterGroupName() != null // could be null when the cluster is in create-failed state
+                                && cluster.parameterGroupStatus() != null // same as above
+                                && cluster.parameterGroupName().equals(request.getDesiredResourceState().getParameterGroupName())) // all db clusters that use the param group
                         .allMatch(dbCluster -> STABILIZED_STATUS.equals(dbCluster.parameterGroupStatus()))) { // if all stabilized then move to the next page
 
                     if (describeClustersResponse.nextToken() != null) { // more pages left


### PR DESCRIPTION
*Issue:*

After the Update handler for parameter group finishes the params update on a PG, it does a describe clusters calls to check if all the associated clusters for the PG have the PG status as "in-sync", but it doesn't handle the case when such clusters are in an inconsistent state (deleting/create-failed etc.,). The pg properties in the describe clusters response could be null in such cases.

*Description of changes:*
added null check for PG name and PG status in waitForStabilize method for PG Update handler

*Testing :*
Contract test results -
https://paste.amazon.com/show/raoadi/1634326800

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
