### PR TITLE
Explicitly specify value for taggable

### DIFF
--- a/aws-memorydb-acl/aws-memorydb-acl.json
+++ b/aws-memorydb-acl/aws-memorydb-acl.json
@@ -2,6 +2,7 @@
     "typeName": "AWS::MemoryDB::ACL",
     "description": "Resource Type definition for AWS::MemoryDB::ACL",
     "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-memorydb",
+    "taggable": true,
     "definitions": {
         "Tag": {
             "description": "A key-value pair to associate with a resource.",

--- a/aws-memorydb-cluster/aws-memorydb-cluster.json
+++ b/aws-memorydb-cluster/aws-memorydb-cluster.json
@@ -2,6 +2,7 @@
     "typeName": "AWS::MemoryDB::Cluster",
     "description": "The AWS::MemoryDB::Cluster resource creates an Amazon MemoryDB Cluster.",
     "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-memorydb",
+    "taggable": true,
     "definitions": {
         "Endpoint": {
             "type": "object",

--- a/aws-memorydb-parametergroup/aws-memorydb-parametergroup.json
+++ b/aws-memorydb-parametergroup/aws-memorydb-parametergroup.json
@@ -2,6 +2,7 @@
     "typeName": "AWS::MemoryDB::ParameterGroup",
     "description": "The AWS::MemoryDB::ParameterGroup resource creates an Amazon MemoryDB ParameterGroup.",
     "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-memorydb",
+    "taggable": true,
     "definitions": {
         "Tag": {
             "description": "A key-value pair to associate with a resource.",

--- a/aws-memorydb-subnetgroup/aws-memorydb-subnetgroup.json
+++ b/aws-memorydb-subnetgroup/aws-memorydb-subnetgroup.json
@@ -2,6 +2,7 @@
     "typeName": "AWS::MemoryDB::SubnetGroup",
     "description": "The AWS::MemoryDB::SubnetGroup resource creates an Amazon MemoryDB Subnet Group.",
     "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-memorydb",
+    "taggable": true,
     "definitions": {
         "Tag": {
             "description": "A key-value pair to associate with a resource.",

--- a/aws-memorydb-user/aws-memorydb-user.json
+++ b/aws-memorydb-user/aws-memorydb-user.json
@@ -2,6 +2,7 @@
     "typeName": "AWS::MemoryDB::User",
     "description": "Resource Type definition for AWS::MemoryDB::User",
     "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-memorydb",
+    "taggable": true,
     "definitions": {
         "Tag": {
             "description": "A key-value pair to associate with a resource.",


### PR DESCRIPTION
*Issue:*
Property "taggable" is set to true by default, but cfn validate complains about the property if not specified explicitly in the resource schema.

*Change:*
 Fix cfn validate warning - 'Explicitly specify value for taggable'

*testing*
cfn validate result-
https://paste.amazon.com/show/raoadi/1634331915

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
