### PR TITLE
add retryErrorFilter for all User resource handlers to retry on unknown failures

### DIFF
--- a/aws-memorydb-acl/src/main/java/software/amazon/memorydb/acl/CreateHandler.java
+++ b/aws-memorydb-acl/src/main/java/software/amazon/memorydb/acl/CreateHandler.java
@@ -37,6 +37,7 @@ public class CreateHandler extends BaseHandlerStd {
                 proxy.initiate("AWS-MemoryDB-ACL::Create", proxyClient, progress.getResourceModel(),
                     progress.getCallbackContext())
                     .translateToServiceRequest(Translator::translateToCreateRequest)
+                    .backoffDelay(STABILIZATION_DELAY)
                     .makeServiceCall((awsRequest, client) -> handleExceptions(() ->
                         client.injectCredentialsAndInvokeV2(awsRequest, client.client()::createACL)))
                     .stabilize(

--- a/aws-memorydb-subnetgroup/src/main/java/software/amazon/memorydb/subnetgroup/DeleteHandler.java
+++ b/aws-memorydb-subnetgroup/src/main/java/software/amazon/memorydb/subnetgroup/DeleteHandler.java
@@ -47,6 +47,7 @@ public class DeleteHandler extends BaseHandlerStd {
 
         return proxy.initiate("AWS-memorydb-SubnetGroup::Delete", proxyClient, request.getDesiredResourceState(), progress.getCallbackContext())
                 .translateToServiceRequest(Translator::translateToDeleteRequest)
+                .backoffDelay(STABILIZATION_DELAY)
                 .makeServiceCall((awsRequest, client) -> handleExceptions(() ->
                         client.injectCredentialsAndInvokeV2(awsRequest, client.client()::deleteSubnetGroup)))
                 .stabilize((awsRequest, awsResponse, client, model, context) -> isDeleted(proxyClient, model))

--- a/aws-memorydb-user/src/main/java/software/amazon/memorydb/user/BaseHandlerStd.java
+++ b/aws-memorydb-user/src/main/java/software/amazon/memorydb/user/BaseHandlerStd.java
@@ -1,14 +1,34 @@
 package software.amazon.memorydb.user;
 
+import com.amazonaws.SdkClientException;
 import com.google.common.base.Throwables;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.memorydb.MemoryDbClient;
+import software.amazon.awssdk.services.memorydb.model.AclNotFoundException;
+import software.amazon.awssdk.services.memorydb.model.ClusterNotFoundException;
+import software.amazon.awssdk.services.memorydb.model.DuplicateUserNameException;
+import software.amazon.awssdk.services.memorydb.model.InvalidArnException;
+import software.amazon.awssdk.services.memorydb.model.InvalidClusterStateException;
+import software.amazon.awssdk.services.memorydb.model.InvalidParameterCombinationException;
+import software.amazon.awssdk.services.memorydb.model.InvalidParameterValueException;
+import software.amazon.awssdk.services.memorydb.model.MemoryDbException;
+import software.amazon.awssdk.services.memorydb.model.ParameterGroupNotFoundException;
+import software.amazon.awssdk.services.memorydb.model.ServiceLinkedRoleNotFoundException;
+import software.amazon.awssdk.services.memorydb.model.SnapshotNotFoundException;
+import software.amazon.awssdk.services.memorydb.model.SubnetGroupNotFoundException;
+import software.amazon.awssdk.services.memorydb.model.TagQuotaPerResourceExceededException;
 import software.amazon.awssdk.services.memorydb.model.User;
 import software.amazon.awssdk.services.memorydb.model.UserAlreadyExistsException;
 import software.amazon.awssdk.services.memorydb.model.UserNotFoundException;
+import software.amazon.awssdk.services.memorydb.model.UserQuotaExceededException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
@@ -23,6 +43,7 @@ import software.amazon.cloudformation.proxy.delay.Constant;
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
   private static final String MESSAGE_FORMAT_FAILED_TO_STABILIZE = "User %s failed to stabilize.";
+  protected static final Integer RETRY_COUNT = 5;
   protected static final Constant STABILIZATION_DELAY = Constant.of()
       .timeout(Duration.ofHours(1L))
       .delay(Duration.ofSeconds(60))
@@ -85,8 +106,40 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
       throw new CfnAlreadyExistsException(e);
     } catch (final UserNotFoundException e) {
       throw new CfnNotFoundException(e);
-    } catch (final AwsServiceException e) {
-      throw new CfnGeneralServiceException(e);
     }
+  }
+
+  protected boolean shouldRetry(Exception exception, CallbackContext context, Logger logger) {
+    if(context.getRetriesRemaining() > 0 && isARetriableException(exception, logger)) {
+      logger.log("Caught a retriable exception, RetriesRemaining " + context.getRetriesRemaining());
+      context.setRetriesRemaining(context.getRetriesRemaining() - 1);
+      return true;
+    }
+    return false;
+  }
+  List<Class<? extends Throwable>> expectedExceptionsList = Arrays.asList(UserAlreadyExistsException.class
+          , UserAlreadyExistsException.class
+          , UserQuotaExceededException.class
+          , DuplicateUserNameException.class
+          , InvalidParameterValueException.class
+          , InvalidParameterCombinationException.class
+          , TagQuotaPerResourceExceededException.class
+          , ClusterNotFoundException.class
+          , InvalidClusterStateException.class
+          , ParameterGroupNotFoundException.class
+          , SubnetGroupNotFoundException.class
+          , InvalidArnException.class
+          , ServiceLinkedRoleNotFoundException.class
+          , UserNotFoundException.class
+          , AclNotFoundException.class
+  );
+  private boolean isARetriableException(Exception exception, Logger logger){
+      if(expectedExceptionsList.stream().filter(eClass -> ExceptionUtils.hasCause(exception, eClass)).collect(Collectors.toList()).size() > 0) {
+        return false;
+      } else {
+        logger.log(exception.toString() + " " + exception.getMessage() + " " + exception.getCause() + "\n"
+                + Throwables.getStackTraceAsString(exception));
+        return true;
+      }
   }
 }

--- a/aws-memorydb-user/src/main/java/software/amazon/memorydb/user/CallbackContext.java
+++ b/aws-memorydb-user/src/main/java/software/amazon/memorydb/user/CallbackContext.java
@@ -2,9 +2,14 @@ package software.amazon.memorydb.user;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 
+@lombok.Data
+@lombok.Builder
+@lombok.NoArgsConstructor
+@lombok.AllArgsConstructor
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    private Integer retriesRemaining;
 }

--- a/aws-memorydb-user/src/main/java/software/amazon/memorydb/user/DeleteHandler.java
+++ b/aws-memorydb-user/src/main/java/software/amazon/memorydb/user/DeleteHandler.java
@@ -21,6 +21,10 @@ public class DeleteHandler extends BaseHandlerStd {
 
         this.logger = logger;
 
+        if (callbackContext.getRetriesRemaining() == null) {
+            callbackContext.setRetriesRemaining(RETRY_COUNT);
+        }
+
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
             .then(progress ->
                 proxy.initiate("AWS-MemoryDB-User::Delete", proxyClient, progress.getResourceModel(),
@@ -41,6 +45,7 @@ public class DeleteHandler extends BaseHandlerStd {
                     .stabilize(
                         (deleteUserRequest, deleteUserResponse, proxyInvocation, model, context) -> isUserDeleted(
                             proxyInvocation, model, logger))
+                    .retryErrorFilter((awsRequest, exception, client, model, context) -> (shouldRetry(exception, context, logger)))
                     .done((deleteUserRequest, deleteUserResponse, proxyInvocation, model, context) -> ProgressEvent
                         .defaultSuccessHandler(null))
             );

--- a/aws-memorydb-user/src/main/java/software/amazon/memorydb/user/UpdateHandler.java
+++ b/aws-memorydb-user/src/main/java/software/amazon/memorydb/user/UpdateHandler.java
@@ -29,6 +29,10 @@ public class UpdateHandler extends BaseHandlerStd {
 
         this.logger = logger;
 
+        if (callbackContext.getRetriesRemaining() == null) {
+            callbackContext.setRetriesRemaining(RETRY_COUNT);
+        }
+
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
             .then(progress -> updateUser(proxy, progress, request, proxyClient))
             .then(progress -> updateTags(proxy, progress, request, proxyClient))
@@ -50,6 +54,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .stabilize(
                     (updateUserRequest, updateUserResponse, proxyInvocation, model, context) -> isUserStabilized(
                         proxyInvocation, model, logger))
+                .retryErrorFilter((awsRequest, exception, client, model, context) -> (shouldRetry(exception, context, logger)))
                 .progress();
         } else {
             return progress;

--- a/aws-memorydb-user/src/test/java/software/amazon/memorydb/user/DeleteHandlerTest.java
+++ b/aws-memorydb-user/src/test/java/software/amazon/memorydb/user/DeleteHandlerTest.java
@@ -2,11 +2,13 @@ package software.amazon.memorydb.user;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import software.amazon.awssdk.services.memorydb.MemoryDbClient;
 import software.amazon.awssdk.services.memorydb.model.DeleteUserRequest;
 import software.amazon.awssdk.services.memorydb.model.DeleteUserResponse;
 import software.amazon.awssdk.services.memorydb.model.DescribeUsersRequest;
 import software.amazon.awssdk.services.memorydb.model.DescribeUsersResponse;
+import software.amazon.awssdk.services.memorydb.model.MemoryDbException;
 import software.amazon.awssdk.services.memorydb.model.UserNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -24,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.atLeastOnce;
@@ -115,5 +118,33 @@ public class DeleteHandlerTest extends AbstractTestBase {
         } catch (CfnNotFoundException e) {
             assertThat(e.getCause() instanceof UserNotFoundException).isTrue();
         }
+    }
+
+    @Test
+    public void handleRequest_FailureUnknown() {
+        doThrow(MemoryDbException.class)
+                .when(proxyClient.client()).deleteUser(any(DeleteUserRequest.class));
+
+        final DeleteHandler handler = new DeleteHandler();
+
+        final ResourceModel model = ResourceModel.builder().build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        ProgressEvent<ResourceModel, CallbackContext> response = null;
+        try {
+            response = handler
+                    .handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext().getRetriesRemaining()).isEqualTo(0);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        verify(sdkClient, atLeast(1)).serviceName();
     }
 }


### PR DESCRIPTION
add retry using retryErrorFilter for All handlers in User resource type to tackle transient and intermittent service request failures. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
